### PR TITLE
Fix import paths in improved branch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,13 +3,13 @@ import { parseArgs } from 'node:util';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { KnowledgeGraphManager } from './src/core/KnowledgeGraphManager.js';
-import { ProjectManager } from './src/managers/ProjectManager.js';
-import { TagManager } from './src/managers/TagManager.js';
-import { SearchManager } from './src/managers/SearchManager.js';
-import { MemoryHealthManager } from './src/managers/MemoryHealthManager.js';
-import { Entity, Relation } from './src/types/interfaces.js';
-import { startHttpServer } from './src/server/httpServer.js';
+import { KnowledgeGraphManager } from './src/core/KnowledgeGraphManager';
+import { ProjectManager } from './src/managers/ProjectManager';
+import { TagManager } from './src/managers/TagManager';
+import { SearchManager } from './src/managers/SearchManager';
+import { MemoryHealthManager } from './src/managers/MemoryHealthManager';
+import { Entity, Relation } from './src/types/interfaces';
+import { startHttpServer } from './src/server/httpServer';
 
 // Parse command line arguments
 const { values } = parseArgs({
@@ -328,4 +328,4 @@ knowledgeGraphManager.readGraph(false)
   .catch((error: any) => {
     console.error('Failed to initialize knowledge graph:', error);
     process.exit(1);
-  }); 
+  });

--- a/src/core/KnowledgeGraphManager.ts
+++ b/src/core/KnowledgeGraphManager.ts
@@ -6,8 +6,8 @@ import {
   SummaryKnowledgeGraph,
   EntitySummary,
   Relation
-} from '../types/interfaces.js';
-import { getCurrentTimestamp } from './utils.js';
+} from '../types/interfaces';
+import { getCurrentTimestamp } from './utils';
 
 /**
  * Core manager for knowledge graph operations
@@ -577,4 +577,4 @@ export class KnowledgeGraphManager {
     
     return relation;
   }
-} 
+}

--- a/src/managers/MemoryHealthManager.ts
+++ b/src/managers/MemoryHealthManager.ts
@@ -1,6 +1,6 @@
-import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager.js';
-import { Entity, MemoryHealthMetrics } from '../types/interfaces.js';
-import { calculateStringDistance, getDateDaysAgo } from '../core/utils.js';
+import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager';
+import { Entity, MemoryHealthMetrics } from '../types/interfaces';
+import { calculateStringDistance, getDateDaysAgo } from '../core/utils';
 
 /**
  * Manages health and maintenance operations for the knowledge graph
@@ -316,4 +316,4 @@ export class MemoryHealthManager {
       return !hasRelations;
     });
   }
-} 
+}

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -1,6 +1,6 @@
-import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager.js';
-import { ProjectEntity, Entity, EntitySummary } from '../types/interfaces.js';
-import { getCurrentTimestamp } from '../core/utils.js';
+import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager';
+import { ProjectEntity, Entity, EntitySummary } from '../types/interfaces';
+import { getCurrentTimestamp } from '../core/utils';
 
 /**
  * Manages project-related operations for the knowledge graph
@@ -269,4 +269,4 @@ export class ProjectManager {
     
     return true;
   }
-} 
+}

--- a/src/managers/SearchManager.ts
+++ b/src/managers/SearchManager.ts
@@ -1,6 +1,6 @@
-import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager.js';
-import { Entity, SearchFilter } from '../types/interfaces.js';
-import { calculateStringDistance } from '../core/utils.js';
+import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager';
+import { Entity, SearchFilter } from '../types/interfaces';
+import { calculateStringDistance } from '../core/utils';
 
 /**
  * Manages search operations for the knowledge graph
@@ -328,4 +328,4 @@ export class SearchManager {
     
     return entities;
   }
-} 
+}

--- a/src/managers/TagManager.ts
+++ b/src/managers/TagManager.ts
@@ -1,5 +1,5 @@
-import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager.js';
-import { Entity, EntitySummary } from '../types/interfaces.js';
+import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager';
+import { Entity, EntitySummary } from '../types/interfaces';
 
 /**
  * Manages tag operations for entities in the knowledge graph
@@ -231,4 +231,4 @@ export class TagManager {
     
     return entities;
   }
-} 
+}

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
-import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager.js';
-import { SearchManager } from '../managers/SearchManager.js';
+import { KnowledgeGraphManager } from '../core/KnowledgeGraphManager';
+import { SearchManager } from '../managers/SearchManager';
 
 // Define tools for MCP compliance
 const mcpTools = [
@@ -254,4 +254,4 @@ export function startHttpServer(
   });
   
   return server;
-} 
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-    "compilerOptions": {
-      "target": "ES2022",
-      "module": "CommonJS",
-      "moduleResolution": "Node",
-      "esModuleInterop": true,
-      "outDir": "./dist",
-      "rootDir": ".",
-      "strict": true,
-      "declaration": true,
-      "sourceMap": true,
-      "skipLibCheck": true,
-      "forceConsistentCasingInFileNames": true
-    },
-    "include": ["src/**/*", "index.ts", "migration.ts"],
-    "exclude": ["node_modules", "dist"]
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2020",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR fixes the issues with the 'improved' branch that were preventing it from working properly.

## Changes
1. Fixed import paths in all TypeScript files - removed `.js` extensions from imports to follow TypeScript conventions
2. Updated `tsconfig.json` to use modern module resolution with `NodeNext`
3. Ensured consistent import style across all files

These changes allow the TypeScript compiler to properly resolve imports and generate JavaScript files with correct module paths.

The root cause of the issues was that the code was importing `.js` files that didn't exist yet (they would only be created after compilation), but TypeScript wasn't configured to handle this pattern correctly.

After these changes, the code should compile and run successfully.